### PR TITLE
Fix specific license in a plugin

### DIFF
--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -488,6 +488,7 @@ class MakePotCommand extends WP_CLI_Command {
 					'Author',
 					'Author URI',
 					'Version',
+					'License',
 					'Domain Path',
 					'Text Domain',
 				];


### PR DESCRIPTION
The doc says: 
```
If a plugin or theme specifies a license in their main plugin file or stylesheet, 
the comment looks like this: 
  Copyright (C) 2018 Example Plugin Author
  This file is distributed under the GPLv2.
```
but it dosen't seems to work for plugins. It looks like the "License" param in get_file_headers was missing.
